### PR TITLE
Fix #2: added url parsing support

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,13 @@
     "body-parser": "^1.18.2",
     "express": "^4.16.2",
     "express-fileupload": "^0.4.0",
-    "libphonenumber-js": "^1.0.7"
+    "html-to-text": "^3.3.0",
+    "jquery": "^3.3.1",
+    "jsdom": "^11.6.2",
+    "libphonenumber-js": "^1.0.7",
+    "tesseract.js": "^1.0.10",
+    "textversionjs": "^1.0.2",
+    "xml2js": "^0.4.19"
   },
   "devDependencies": {
     "chai": "^4.1.2",

--- a/server.js
+++ b/server.js
@@ -36,13 +36,9 @@ router.get('/text/:string', (req, res) => {
 // allow sending of url links to be parsed.
 //note need  to send as www.{...string...}.com to work properly work
 router.get('/http/:string', (req, res) => {
-    var url = require('url');
-    var rt = [];
-    var text = req.params.string;
-    console.log(text);
 
     var options = {
-      host: text,
+      host: req.params.string,
       path: '/',
     }
     //note the ress. had to put that because it conflicts with res in router
@@ -55,7 +51,6 @@ router.get('/http/:string', (req, res) => {
         var textVersion = require("textversionjs");
         var plainText = textVersion(data);
         var phrases = data.split("\n");
-        console.log(phrases);
         for(var i = 0; i < phrases.length; i++){
           var result = libphonenumber.parse(phrases[i], "CA");
           if (!isEmpty(result)) {
@@ -75,13 +70,9 @@ router.get('/http/:string', (req, res) => {
 // allow sending of url links to be parsed.
 // note need  to send as www.{...string...}.com to work properly work
 router.get('/https/:string', (req, res) => {
-    var url = require('url');
-    var rt = [];
-    var text = req.params.string;
-    console.log(text);
 
     var options = {
-      host: text,
+      host: req.params.string,
       path: '/',
     }
     //note the ress. had to put that because it conflicts with res in router
@@ -94,7 +85,6 @@ router.get('/https/:string', (req, res) => {
         var textVersion = require("textversionjs");
         var plainText = textVersion(data);
         var phrases = data.split("\n");
-        console.log(phrases);
         for(var i = 0; i < phrases.length; i++){
           var result = libphonenumber.parse(phrases[i], "CA");
           if (!isEmpty(result)) {

--- a/server.js
+++ b/server.js
@@ -5,6 +5,8 @@ var express = require('express');
 var bodyParser = require('body-parser');
 var upload = require('express-fileupload');
 var libphonenumber = require('libphonenumber-js');
+var https = require('https');
+var http = require('http');
 
 var app = express();
 var port = process.env.port || 3000;
@@ -30,6 +32,84 @@ router.get('/text/:string', (req, res) => {
     return res.status(200).send(rt);
 });
 
+// GET /api/phonenumbers/parse/url/{...website...}
+// allow sending of url links to be parsed.
+//note need  to send as www.{...string...}.com to work properly work
+router.get('/http/:string', (req, res) => {
+    var url = require('url');
+    var rt = [];
+    var text = req.params.string;
+    console.log(text);
+
+    var options = {
+      host: text,
+      path: '/',
+    }
+    //note the ress. had to put that because it conflicts with res in router
+    var request = http.request(options, function (ress) {
+      var data = '';
+      ress.on('data', function (chunk) {
+        data += chunk;
+      });
+      ress.on('end', function () {
+        var textVersion = require("textversionjs");
+        var plainText = textVersion(data);
+        var phrases = data.split("\n");
+        console.log(phrases);
+        for(var i = 0; i < phrases.length; i++){
+          var result = libphonenumber.parse(phrases[i], "CA");
+          if (!isEmpty(result)) {
+              rt.push(libphonenumber.format(result, 'National'));
+          }
+        }
+        return res.status(200).send(rt);
+      });
+    });
+    request.on('error', function (err) {
+      console.log(err.message);
+    });
+    request.end();
+});
+
+// GET /api/phonenumbers/parse/https/{...website...}
+// allow sending of url links to be parsed.
+// note need  to send as www.{...string...}.com to work properly work
+router.get('/https/:string', (req, res) => {
+    var url = require('url');
+    var rt = [];
+    var text = req.params.string;
+    console.log(text);
+
+    var options = {
+      host: text,
+      path: '/',
+    }
+    //note the ress. had to put that because it conflicts with res in router
+    var request = https.request(options, function (ress) {
+      var data = '';
+      ress.on('data', function (chunk) {
+        data += chunk;
+      });
+      ress.on('end', function () {
+        var textVersion = require("textversionjs");
+        var plainText = textVersion(data);
+        var phrases = data.split("\n");
+        console.log(phrases);
+        for(var i = 0; i < phrases.length; i++){
+          var result = libphonenumber.parse(phrases[i], "CA");
+          if (!isEmpty(result)) {
+              rt.push(libphonenumber.format(result, 'National'));
+          }
+        }
+        return res.status(200).send(rt);
+      });
+    });
+    request.on('error', function (err) {
+      console.log(err.message);
+    });
+    request.end();
+});
+
 // send file page
 router.get('/file', (req, res) => {
     res.sendFile(__dirname + "/fileupload.html");
@@ -44,11 +124,11 @@ router.post('/file', function(req, res) {
     } else {
         let mfile = req.files.mfile;
         var rt = [];
-        
+
         var fs = require('fs');
         fs.readFileSync(mfile.name).toString().split('\n').forEach(function (line) {
             var phone = libphonenumber.parse(line, "CA");
-            
+
             if (!isEmpty(phone)) {
                 rt.push(libphonenumber.format(phone, 'National'));
             }


### PR DESCRIPTION
This PR adds support for parsing a URL resource.
The route to use http link is: `/api/phonenumbers/parse/http/{...website...}`.
The route to use https link is: `/api/phonenumbers/parse/https/{...website...}`.
There is a couple of things to note about this feature.
First is that the url has to be formatted like this: `/api/phonenumbers/parse/url/www.example.com`.
Also, it cannot have extra paths attached to it.

Also sometimes this feature will sometimes not be able to return a phone number.
I found that this feature is able to parse wordpress sites for phone numbers but this feature is really picky with it's phone numbers.
I can give addition cases where it fails or passes.
This is caused by the module textversionjs not being able to correctly parse the text.

Thanks for considering this request.